### PR TITLE
Fix  dialog only if necessary

### DIFF
--- a/view/frontend/templates/modal_container.phtml
+++ b/view/frontend/templates/modal_container.phtml
@@ -18,7 +18,7 @@
 ?>
 
 <?php if ($this->showModal()): ?>
-    <div data-mage-init='{"countryModal":{"contentPath": "<?php echo $this->getModalContentUrl('popup/Popup/Index'); ?>"}}' id="language-modal" style="display:none;">
+    <div data-mage-init='{"countryModal":{"contentPath": "<?php echo $this->getModalContentUrl('popup/Popup/Index'); ?>"}}' id="language-modal" class="hide-country-popup" style="display:none;">
         <div class="img-wrapper">
             <img class="modal-image" />
         </div>

--- a/view/frontend/web/js/country_modal.js
+++ b/view/frontend/web/js/country_modal.js
@@ -78,11 +78,12 @@ define([
                     responsive: this.options.modal_responsive,
                     innerScroll: true,
                     wrapperClass: 'hint-country-modal'
-                },
-                popup = modal(options, this.element);
+                };
 
             if (!this.options.show_modal && !this.options.default_store) {
-                setTimeout(function () {
+                // only init modal dialog if necessary
+                modal(options, this.element);
+                this.element.removeClass('hide-country-popup');
                     that.element.modal('openModal', true);
                     if (!that.options.show_modal_overlay) {
                         $('.hint-country-modal').addClass('no-overlay');

--- a/view/frontend/web/js/country_modal.js
+++ b/view/frontend/web/js/country_modal.js
@@ -84,6 +84,7 @@ define([
                 // only init modal dialog if necessary
                 modal(options, this.element);
                 this.element.removeClass('hide-country-popup');
+                setTimeout(function () {
                     that.element.modal('openModal', true);
                     if (!that.options.show_modal_overlay) {
                         $('.hint-country-modal').addClass('no-overlay');


### PR DESCRIPTION
If the dialog remains closed, other dialogs should be able to query this in order to better control dependencies.